### PR TITLE
patch api attribute error

### DIFF
--- a/ros2_aruco/ros2_aruco/aruco_node.py
+++ b/ros2_aruco/ros2_aruco/aruco_node.py
@@ -145,8 +145,8 @@ class ArucoNode(rclpy.node.Node):
         self.intrinsic_mat = None
         self.distortion = None
 
-        self.aruco_dictionary = cv2.aruco.Dictionary_get(dictionary_id)
-        self.aruco_parameters = cv2.aruco.DetectorParameters_create()
+        self.aruco_dictionary = cv2.aruco.getPredefinedDictionary(dictionary_id)
+        self.aruco_parameters = cv2.aruco.DetectorParameters()
         self.bridge = CvBridge()
 
     def info_callback(self, info_msg):


### PR DESCRIPTION
the last update of cv2 has introduced API changes that result in error:

`"AttributeError: module 'cv2.aruco' has no attribute 'Dictionary_get'"`

this commit brings back API compatibility with regards to _dictionary_ and _parameters_ values